### PR TITLE
Allow binary to be used in the latest Origam Architect (.Net Framewor…

### DIFF
--- a/src/Origam.Ftp/Origam.Ftp/FtpServiceAgent.cs
+++ b/src/Origam.Ftp/Origam.Ftp/FtpServiceAgent.cs
@@ -41,7 +41,8 @@ namespace Origam.Ftp
         public void Run()
         {
             var useSecuredConnection = true;
-            if (Parameters["UseSecuredConnection"] is bool useSecuredConnectionParam)
+            if(Parameters["UseSecuredConnection"] 
+               is bool useSecuredConnectionParam)
             {
                 useSecuredConnection = useSecuredConnectionParam;
             }
@@ -67,20 +68,19 @@ namespace Origam.Ftp
             string password,
             string path)
         {
-            if (log.IsDebugEnabled)
+            if(log.IsDebugEnabled)
             {
                 log.DebugFormat(
                     "Downloading {0} from {1}.", path, host);
             }
-
-            using (FtpClient ftp = new FtpClient(host, username, password))
+            using(var ftp = new FtpClient(host, username, password))
             {
-                if (useSecuredConnection)
+                if(useSecuredConnection)
                 {
                     ftp.EncryptionMode = FtpEncryptionMode.Explicit;
                 }
                 ftp.Connect();
-                using (MemoryStream output = new MemoryStream())
+                using(var output = new MemoryStream())
                 {
                     ftp.Download(output, path);
                     return output.ToArray();

--- a/src/Origam.Ftp/Origam.Ftp/FtpServiceAgent.cs
+++ b/src/Origam.Ftp/Origam.Ftp/FtpServiceAgent.cs
@@ -19,62 +19,73 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 #endregion
 
+using System;
 using System.Collections;
+using System.IO;
 using FluentFTP;
 using log4net;
 using Origam.Service.Core;
 
-namespace Origam.Ftp;
-
-public class FtpServiceAgent : IExternalServiceAgent
+namespace Origam.Ftp
 {
-    private static readonly ILog log = 
-        LogManager.GetLogger(typeof(FtpServiceAgent));
-
-    public object Result { get; private set; } = null!;
-    public Hashtable Parameters { get; } = new();
-    public string MethodName { get; set; } = null!;
-    public string TransactionId { get; set; } = null!;
-
-    public void Run()
+    public class FtpServiceAgent : IExternalServiceAgent
     {
-        var useSecuredConnection = true;
-        if(Parameters["UseSecuredConnection"] is bool useSecuredConnectionParam)
+        private static readonly ILog log =
+            LogManager.GetLogger(typeof(FtpServiceAgent));
+
+        public object Result { get; private set; }
+        public Hashtable Parameters { get; } = new Hashtable();
+        public string MethodName { get; set; }
+        public string TransactionId { get; set; }
+
+        public void Run()
         {
-            useSecuredConnection = useSecuredConnectionParam;
+            var useSecuredConnection = true;
+            if (Parameters["UseSecuredConnection"] is bool useSecuredConnectionParam)
+            {
+                useSecuredConnection = useSecuredConnectionParam;
+            }
+            switch (MethodName)
+            {
+                case "DownloadFile":
+                    Result = DownloadFile(
+                    Parameters.Get<string>("Host"),
+                    useSecuredConnection,
+                    Parameters.Get<string>("Username"),
+                    Parameters.Get<string>("Password"),
+                    Parameters.Get<string>("Path"));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(@"MethodName",
+                    MethodName);
+            }   
         }
-        Result = MethodName switch
+        private static object DownloadFile(
+            string host,
+            bool useSecuredConnection,
+            string username,
+            string password,
+            string path)
         {
-            "DownloadFile" => DownloadFile(
-                Parameters.Get<string>("Host"),
-                useSecuredConnection,
-                Parameters.Get<string>("Username"),
-                Parameters.Get<string>("Password"),
-                Parameters.Get<string>("Path")),
-            _ => throw new ArgumentOutOfRangeException(@"MethodName",
-                MethodName)
-        };
-    }
-    private static object DownloadFile(
-        string host, 
-        bool useSecuredConnection,
-        string username, 
-        string password, 
-        string path)
-    {
-        if(log.IsDebugEnabled)
-        {
-            log.DebugFormat(
-                "Downloading {0} from {1}.", path, host);
+            if (log.IsDebugEnabled)
+            {
+                log.DebugFormat(
+                    "Downloading {0} from {1}.", path, host);
+            }
+
+            using (FtpClient ftp = new FtpClient(host, username, password))
+            {
+                if (useSecuredConnection)
+                {
+                    ftp.EncryptionMode = FtpEncryptionMode.Explicit;
+                }
+                ftp.Connect();
+                using (MemoryStream output = new MemoryStream())
+                {
+                    ftp.Download(output, path);
+                    return output.ToArray();
+                }
+            }
         }
-        using var ftp = new FtpClient(host, username, password);
-        using var output = new MemoryStream();
-        if(useSecuredConnection)
-        {
-            ftp.EncryptionMode = FtpEncryptionMode.Explicit;
-        }
-        ftp.Connect();
-        ftp.Download(output, path);
-        return output.ToArray();
     }
 }

--- a/src/Origam.Ftp/Origam.Ftp/Origam.Ftp.csproj
+++ b/src/Origam.Ftp/Origam.Ftp/Origam.Ftp.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyVersion>1.0.1</AssemblyVersion>
         <FileVersion>1.0.1</FileVersion>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Origam.Ftp/Origam.Ftp/Origam.Ftp.csproj
+++ b/src/Origam.Ftp/Origam.Ftp/Origam.Ftp.csproj
@@ -2,11 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <AssemblyVersion>1.0.1</AssemblyVersion>
-        <FileVersion>1.0.1</FileVersion>
+        <AssemblyVersion>1.1.0</AssemblyVersion>
+        <FileVersion>1.1.0</FileVersion>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <Copyright>Advantage Solutions s. r. o.</Copyright>
-        <PackageVersion>1.0.1</PackageVersion>
+        <PackageVersion>1.1.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
…k 4.7.2). So this library has to go to .NET standard 2.0. See https://learn.microsoft.com/cs-cz/dotnet/standard/net-standard?tabs=net-standard-2-0